### PR TITLE
Add the accessibility_status and accessibility_notes fields to Events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ Requires authentication: Yes
 | `created_by_volunteer_host`      | bool          | Whether the event was created by a volunteer host using our distributed organizing tool or not                                                                                                                                          |
 | `virtual_action_url` | string       | The url the event redirects to if it's an unshifted virtual event. Otherwise, `null`.                                                                   |
 | `contact`            | Contact      | The contact information for the event |
+| `accessibility_status`           | enum          | The degree of compliance with the Americans with Disabilities Act. One of: `ACCESSIBLE`, `NOT_ACCESSIBLE`, `NOT_SURE`, or `null`           |
+| `accessibility_notes`| string       | Additional details about accessibility status and accomodations at the venue                                                                            |
 
 ### Timeslot
 
@@ -464,8 +466,9 @@ Requires authentication: No
                   "204 E 13th St",
                   ""
               ],
-              "locality": "",
-              "region": "",
+              "locality": "New York",
+              "region": "NY",
+              "country": "US",
               "postal_code": "10003",
               "location": {
                   "latitude": 40.7322535,
@@ -556,6 +559,8 @@ Requires authentication: Yes
 | `timezone`           | string       | A timezone database string for the event, one of: `America/New_York`, `Pacific/Honolulu`, `America/Los_Angeles`, `America/Denver`, `America/Phoenix`, `America/Chicago`.                                | Yes
 | `event_type`         | string       | The type of the event, one of: `CANVASS`, `PHONE_BANK`, `TEXT_BANK`, `MEETING`, `COMMUNITY`, `FUNDRAISER`, `MEET_GREET`, `HOUSE_PARTY`, `VOTER_REG`, `TRAINING`, `FRIEND_TO_FRIEND_OUTREACH`, `OTHER`.  | Yes
 | `visibility`         | string       | The visibility of the event, one of: `PUBLIC`, `PRIVATE`.                                                                                                                                               | Yes
+| `accessibility_status` | string     | The level of compliance with the [Americans with Disabilities Act](https://www.access-board.gov/guidelines-and-standards/buildings-and-sites/about-the-ada-standards/guide-to-the-ada-standards/single-file-version) for the event venue, one of: `ACCESSIBLE`, `NOT_ACCESSIBLE`, `NOT_SURE`. If you set this to `ACCESSIBLE`, you are responsible for ensuring that your venue meets ADA standards. | Yes
+| `accessibility_notes`  | string     | Notes with additional information about accessibility at the event location, including the availability of ramps and wheelchair-accessible restrooms, the height of door thresholds, the number of stairs, and the nature of any parking or seating arrangements. This is helpful even for venues that are not fully ADA accessible.| No
 
 ### Request body example
 
@@ -588,7 +593,9 @@ Requires authentication: Yes
         "visibility": "PUBLIC",
         "contact": {
             "email_address": "replyto@thisemail.com"
-        }
+        },
+        "accessibility_status": "ACCESSIBLE",
+        "accessibility_notes": "There is a wheelchair ramp at the southern entrance for the staging area. We have two vans with wheelchair lifts."
     }
 
 ### Response
@@ -1018,6 +1025,9 @@ If any required fields are missing or contain invalid values, the endpoint will 
 On a successful request, the endpoint will return a 201 Created status code if the person record was created, a 200 No Content result if the person record was updated, and the affected Affiliation object.
 
 # Changelog
+
+**2019-07-19**
+- Add `accessibility_status` and `accessibility_notes` to [Event object](#event-object)
 
 **2019-07-18**
 - Add `country` to [Location object](#location-object)


### PR DESCRIPTION
`accessibility_status` and `accessibility_notes` have been added to the events read and write endpoints.

I also updated a few things in the example response related to location.